### PR TITLE
feat: add endpoint to create player with wallet

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,10 +1,9 @@
 import Boom from '@hapi/boom';
 
 const badData = (message?: string) => Boom.badData(message);
+const conflict = (message?: string) => Boom.conflict(message);
 const notFound = (message?: string) => Boom.notFound(message);
 
 export const paramNotValidError = badData;
-export const userNotExistError = notFound;
 export const gameNotExistError = notFound;
 export const conversationNotExistError = notFound;
-export const userHasNotInternalAccountError = notFound;

--- a/src/route-versions/v1/controllers/player.controller.ts
+++ b/src/route-versions/v1/controllers/player.controller.ts
@@ -1,0 +1,34 @@
+import { interfaces } from '@numengames/numinia-logger';
+import Bluebird from 'bluebird';
+import { Request, Response, NextFunction } from 'express';
+
+import { PlayerServiceAttributes } from '../../../services/player.service';
+import validateCreatePlayerWithWalletInputParams from '../../../validators/validate-create-player-with-wallet-input-params';
+
+export interface PlayerControllerAttributes {
+  createPlayerWithWallet: (req: Request, res: Response, next: NextFunction) => void;
+}
+
+type PlayerControllerParams = {
+  playerService: PlayerServiceAttributes
+  loggerHandler: (title: string) => interfaces.ILogger;
+};
+
+export default class PlayerController implements PlayerControllerAttributes {
+  private readonly logger;
+
+  private readonly playerService;
+
+  constructor({ loggerHandler, playerService }: PlayerControllerParams) {
+    this.playerService = playerService;
+    this.logger = loggerHandler('PlayerController');
+  }
+
+  createPlayerWithWallet(req: Request, res: Response, next: NextFunction): void {
+    Bluebird.resolve(req.body)
+      .then(validateCreatePlayerWithWalletInputParams)
+      .then(this.playerService.createPlayerWithWalletIfNotExist.bind(this.playerService))
+      .then(res.status(201).send.bind(res))
+      .catch(next);
+  }
+}

--- a/src/route-versions/v1/index.ts
+++ b/src/route-versions/v1/index.ts
@@ -1,15 +1,17 @@
 import { createLoggerHandler as loggerHandler } from '@numengames/numinia-logger';
 import { Router } from 'express';
 
-import DiscordRoutes from './routes/discord.routes';
 import MonitRoutes from './routes/monit.routes';
 import ScoreRoutes from './routes/score.routes';
+import PlayerRoutes from './routes/player.routes';
+import DiscordRoutes from './routes/discord.routes';
 
 export default () => {
   const router = Router();
 
   router.use('/score', new ScoreRoutes(loggerHandler).router);
   router.use('/monit', new MonitRoutes(loggerHandler).router);
+  router.use('/player', new PlayerRoutes(loggerHandler).router);
   router.use('/discord', new DiscordRoutes(loggerHandler).router);
 
   return router;

--- a/src/route-versions/v1/routes/player.routes.ts
+++ b/src/route-versions/v1/routes/player.routes.ts
@@ -1,0 +1,26 @@
+import { interfaces as loggerInterfaces } from '@numengames/numinia-logger';
+import { Router } from 'express';
+
+import { playerService } from '../../../services';
+import PlayerController, { PlayerControllerAttributes } from '../controllers/player.controller';
+
+export default class PlayerRoutes {
+  router: Router;
+
+  private playerController: PlayerControllerAttributes;
+
+  constructor(loggerHandler: (title: string) => loggerInterfaces.ILogger) {
+    this.router = Router();
+
+    this.playerController = new PlayerController({
+      playerService,
+      loggerHandler,
+    });
+
+    this.routes();
+  }
+
+  routes(): void {
+    this.router.post('/create', this.playerController.createPlayerWithWallet.bind(this.playerController));
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,14 +1,16 @@
 import { createLoggerHandler as loggerHandler } from '@numengames/numinia-logger';
-import { GameModel, GameScoreModel, UserModel } from '@numengames/numinia-models';
+import { GameModel, GameScoreModel, PlayerModel } from '@numengames/numinia-models';
 
-import DiscordService from './discord.service';
 import ScoreService from './score.service';
+import PlayerService from './player.service';
+import DiscordService from './discord.service';
 
 export const scoreService = new ScoreService({
-  UserModel,
   GameModel,
+  PlayerModel,
   loggerHandler,
   GameScoreModel,
 });
 
 export const discordService = new DiscordService({ loggerHandler });
+export const playerService = new PlayerService({ PlayerModel, loggerHandler });

--- a/src/services/player.service.ts
+++ b/src/services/player.service.ts
@@ -1,0 +1,37 @@
+import { interfaces as modelInterfaces } from '@numengames/numinia-models';
+import { interfaces as loggerInterfaces } from '@numengames/numinia-logger';
+import { Model } from 'mongoose';
+
+export interface PlayerServiceAttributes {
+  createPlayerWithWalletIfNotExist({ walletId, userName }: Record<string, string>): Promise<void>;
+}
+
+interface PlayerServiceConstructor {
+  PlayerModel: Model<modelInterfaces.PlayerAttributes>;
+  loggerHandler: (title: string) => loggerInterfaces.ILogger;
+}
+
+export default class PlayerService implements PlayerServiceAttributes {
+  private readonly logger: loggerInterfaces.ILogger;
+
+  private PlayerModel: Model<modelInterfaces.PlayerAttributes>;
+
+  constructor({ PlayerModel, loggerHandler }: PlayerServiceConstructor) {
+    this.PlayerModel = PlayerModel;
+    this.logger = loggerHandler('PlayerService');
+  }
+
+  private async doesPlayerByWalletIdExist(walletId: string): Promise<boolean> {
+    const playerDocumennt = this.PlayerModel.exists({ walletId });
+    return playerDocumennt !== null;
+  }
+
+  async createPlayerWithWalletIfNotExist({ walletId, userName }: Record<string, string>): Promise<void> {
+    const playerDocumentExists = await this.doesPlayerByWalletIdExist(walletId);
+
+    if (!playerDocumentExists) {
+      await this.PlayerModel.create({ walletId, userName });
+    }
+
+  }
+}

--- a/src/validators/validate-create-player-with-wallet-input-params.ts
+++ b/src/validators/validate-create-player-with-wallet-input-params.ts
@@ -1,0 +1,18 @@
+import { Request } from 'express';
+import Joi from 'joi';
+
+import { paramNotValidError } from '../errors';
+
+export const schema = Joi.object({
+  walletId: Joi.string().trim().required(),
+  userName: Joi.string().trim().required(),
+}).required();
+
+export default async (body: Request['body']) => {
+  try {
+    const response = await schema.validateAsync(body);
+    return response;
+  } catch (error: unknown) {
+    throw paramNotValidError((error as Joi.ValidationError).message);
+  }
+};


### PR DESCRIPTION
- Added new endpoint `/player/create` to register users with a wallet
- Added player controller to handle player creation
- Updated player routes to include the new endpoint
- Added validation to ensure only users with a wallet can be registered